### PR TITLE
Fixed wrong base type for aeon day type

### DIFF
--- a/src/Aeon/Doctrine/Calendar/Gregorian/DateTimeType.php
+++ b/src/Aeon/Doctrine/Calendar/Gregorian/DateTimeType.php
@@ -7,8 +7,9 @@ namespace Aeon\Doctrine\Calendar\Gregorian;
 use Aeon\Calendar\Gregorian\DateTime;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\DateTimeImmutableType;
 
-final class DateTimeType extends \Doctrine\DBAL\Types\DateTimeType
+final class DateTimeType extends DateTimeImmutableType
 {
     public const NAME = 'aeon_datetime';
 
@@ -33,7 +34,7 @@ final class DateTimeType extends \Doctrine\DBAL\Types\DateTimeType
             return $value->format($platform->getDateTimeFormatString());
         }
 
-        throw ConversionException::conversionFailedInvalidType($value, $this->getName(), ['null', 'DateTime']);
+        throw ConversionException::conversionFailedInvalidType($value, $this->getName(), ['null', 'DateTime', '\DateTimeInterface']);
     }
 
     /**

--- a/src/Aeon/Doctrine/Calendar/Gregorian/DateTimeTzType.php
+++ b/src/Aeon/Doctrine/Calendar/Gregorian/DateTimeTzType.php
@@ -7,8 +7,9 @@ namespace Aeon\Doctrine\Calendar\Gregorian;
 use Aeon\Calendar\Gregorian\DateTime;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\DateTimeTzImmutableType;
 
-final class DateTimeTzType extends \Doctrine\DBAL\Types\DateTimeTzType
+final class DateTimeTzType extends DateTimeTzImmutableType
 {
     public const NAME = 'aeon_datetime_tz';
 
@@ -33,7 +34,7 @@ final class DateTimeTzType extends \Doctrine\DBAL\Types\DateTimeTzType
             return $value->format($platform->getDateTimeTzFormatString());
         }
 
-        throw ConversionException::conversionFailedInvalidType($value, $this->getName(), ['null', 'DateTime']);
+        throw ConversionException::conversionFailedInvalidType($value, $this->getName(), ['null', 'DateTime', '\DateTimeInterface']);
     }
 
     /**

--- a/src/Aeon/Doctrine/Calendar/Gregorian/DayType.php
+++ b/src/Aeon/Doctrine/Calendar/Gregorian/DayType.php
@@ -7,8 +7,9 @@ namespace Aeon\Doctrine\Calendar\Gregorian;
 use Aeon\Calendar\Gregorian\Day;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\DateImmutableType;
 
-final class DayType extends \Doctrine\DBAL\Types\DateTimeType
+final class DayType extends DateImmutableType
 {
     public const NAME = 'aeon_day';
 
@@ -33,7 +34,7 @@ final class DayType extends \Doctrine\DBAL\Types\DateTimeType
             return $value->format($platform->getDateFormatString());
         }
 
-        throw ConversionException::conversionFailedInvalidType($value, $this->getName(), ['null', 'Day']);
+        throw ConversionException::conversionFailedInvalidType($value, $this->getName(), ['null', 'Day', '\DateTimeInterface']);
     }
 
     /**


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>wrong base type for aeon day type</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Updated</h4>
  <ul id="updated">
    <!-- <li>Something, for example, version of dependency</li> -->
  </ul>    
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->
