### PR TITLE
Add return types to doctrine types to handle deprecations

### DIFF
--- a/src/Aeon/Doctrine/Calendar/Gregorian/DateTimeType.php
+++ b/src/Aeon/Doctrine/Calendar/Gregorian/DateTimeType.php
@@ -24,7 +24,7 @@ final class DateTimeType extends DateTimeImmutableType
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform): string
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
     {
         if ($value === null) {
             return $value;
@@ -40,7 +40,7 @@ final class DateTimeType extends DateTimeImmutableType
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform): DateTime
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?DateTime
     {
         if ($value === null || $value instanceof DateTime) {
             return $value;

--- a/src/Aeon/Doctrine/Calendar/Gregorian/DateTimeType.php
+++ b/src/Aeon/Doctrine/Calendar/Gregorian/DateTimeType.php
@@ -16,7 +16,7 @@ final class DateTimeType extends DateTimeImmutableType
     /**
      * {@inheritdoc}
      */
-    public function getName(): string
+    public function getName() : string
     {
         return self::NAME;
     }
@@ -24,7 +24,7 @@ final class DateTimeType extends DateTimeImmutableType
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
+    public function convertToDatabaseValue($value, AbstractPlatform $platform) : ?string
     {
         if ($value === null) {
             return $value;
@@ -40,7 +40,7 @@ final class DateTimeType extends DateTimeImmutableType
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform): ?DateTime
+    public function convertToPHPValue($value, AbstractPlatform $platform) : ?DateTime
     {
         if ($value === null || $value instanceof DateTime) {
             return $value;
@@ -59,7 +59,7 @@ final class DateTimeType extends DateTimeImmutableType
         return $val;
     }
 
-    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
+    public function requiresSQLCommentHint(AbstractPlatform $platform) : bool
     {
         return true;
     }

--- a/src/Aeon/Doctrine/Calendar/Gregorian/DateTimeType.php
+++ b/src/Aeon/Doctrine/Calendar/Gregorian/DateTimeType.php
@@ -16,7 +16,7 @@ final class DateTimeType extends DateTimeImmutableType
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return self::NAME;
     }
@@ -24,7 +24,7 @@ final class DateTimeType extends DateTimeImmutableType
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): string
     {
         if ($value === null) {
             return $value;
@@ -40,7 +40,7 @@ final class DateTimeType extends DateTimeImmutableType
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform): DateTime
     {
         if ($value === null || $value instanceof DateTime) {
             return $value;
@@ -59,7 +59,7 @@ final class DateTimeType extends DateTimeImmutableType
         return $val;
     }
 
-    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
     {
         return true;
     }

--- a/src/Aeon/Doctrine/Calendar/Gregorian/DateTimeTzType.php
+++ b/src/Aeon/Doctrine/Calendar/Gregorian/DateTimeTzType.php
@@ -16,7 +16,7 @@ final class DateTimeTzType extends DateTimeTzImmutableType
     /**
      * {@inheritdoc}
      */
-    public function getName(): string
+    public function getName() : string
     {
         return self::NAME;
     }
@@ -24,7 +24,7 @@ final class DateTimeTzType extends DateTimeTzImmutableType
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
+    public function convertToDatabaseValue($value, AbstractPlatform $platform) : ?string
     {
         if ($value === null) {
             return $value;
@@ -40,7 +40,7 @@ final class DateTimeTzType extends DateTimeTzImmutableType
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform): ?DateTime
+    public function convertToPHPValue($value, AbstractPlatform $platform) : ?DateTime
     {
         if ($value === null || $value instanceof DateTime) {
             return $value;
@@ -59,7 +59,7 @@ final class DateTimeTzType extends DateTimeTzImmutableType
         return $val;
     }
 
-    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
+    public function requiresSQLCommentHint(AbstractPlatform $platform) : bool
     {
         return true;
     }

--- a/src/Aeon/Doctrine/Calendar/Gregorian/DateTimeTzType.php
+++ b/src/Aeon/Doctrine/Calendar/Gregorian/DateTimeTzType.php
@@ -24,7 +24,7 @@ final class DateTimeTzType extends DateTimeTzImmutableType
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform): string
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
     {
         if ($value === null) {
             return $value;
@@ -40,7 +40,7 @@ final class DateTimeTzType extends DateTimeTzImmutableType
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform): DateTime
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?DateTime
     {
         if ($value === null || $value instanceof DateTime) {
             return $value;

--- a/src/Aeon/Doctrine/Calendar/Gregorian/DateTimeTzType.php
+++ b/src/Aeon/Doctrine/Calendar/Gregorian/DateTimeTzType.php
@@ -16,7 +16,7 @@ final class DateTimeTzType extends DateTimeTzImmutableType
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return self::NAME;
     }
@@ -24,7 +24,7 @@ final class DateTimeTzType extends DateTimeTzImmutableType
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): string
     {
         if ($value === null) {
             return $value;
@@ -40,7 +40,7 @@ final class DateTimeTzType extends DateTimeTzImmutableType
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform): DateTime
     {
         if ($value === null || $value instanceof DateTime) {
             return $value;
@@ -59,7 +59,7 @@ final class DateTimeTzType extends DateTimeTzImmutableType
         return $val;
     }
 
-    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
     {
         return true;
     }

--- a/src/Aeon/Doctrine/Calendar/Gregorian/DayType.php
+++ b/src/Aeon/Doctrine/Calendar/Gregorian/DayType.php
@@ -16,7 +16,7 @@ final class DayType extends DateImmutableType
     /**
      * {@inheritdoc}
      */
-    public function getName(): string
+    public function getName() : string
     {
         return self::NAME;
     }
@@ -24,7 +24,7 @@ final class DayType extends DateImmutableType
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
+    public function convertToDatabaseValue($value, AbstractPlatform $platform) : ?string
     {
         if ($value === null) {
             return $value;
@@ -40,7 +40,7 @@ final class DayType extends DateImmutableType
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform): ?Day
+    public function convertToPHPValue($value, AbstractPlatform $platform) : ?Day
     {
         if ($value === null || $value instanceof Day) {
             return $value;
@@ -59,7 +59,7 @@ final class DayType extends DateImmutableType
         return $val;
     }
 
-    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
+    public function requiresSQLCommentHint(AbstractPlatform $platform) : bool
     {
         return true;
     }

--- a/src/Aeon/Doctrine/Calendar/Gregorian/DayType.php
+++ b/src/Aeon/Doctrine/Calendar/Gregorian/DayType.php
@@ -24,7 +24,7 @@ final class DayType extends DateImmutableType
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform): string
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
     {
         if ($value === null) {
             return $value;
@@ -40,7 +40,7 @@ final class DayType extends DateImmutableType
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform): Day
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?Day
     {
         if ($value === null || $value instanceof Day) {
             return $value;

--- a/src/Aeon/Doctrine/Calendar/Gregorian/DayType.php
+++ b/src/Aeon/Doctrine/Calendar/Gregorian/DayType.php
@@ -16,7 +16,7 @@ final class DayType extends DateImmutableType
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return self::NAME;
     }
@@ -24,7 +24,7 @@ final class DayType extends DateImmutableType
     /**
      * {@inheritdoc}
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): string
     {
         if ($value === null) {
             return $value;
@@ -40,7 +40,7 @@ final class DayType extends DateImmutableType
     /**
      * {@inheritdoc}
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    public function convertToPHPValue($value, AbstractPlatform $platform): Day
     {
         if ($value === null || $value instanceof Day) {
             return $value;
@@ -59,7 +59,7 @@ final class DayType extends DateImmutableType
         return $val;
     }
 
-    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
     {
         return true;
     }


### PR DESCRIPTION
<h2>Change Log</h2> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Added return types to Doctrine types to fix deprecation</li>
  </ul>  
  <h4>Updated</h4>
  <ul id="updated">
    <!-- <li>Something, for example, version of dependency</li> -->
  </ul>    
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

When using this bundle in a Symfony project, the following deprecations are triggered:

```
2022-07-04T10:05:39+02:00 [info] User Deprecated: Method "Doctrine\DBAL\Types\Type::getName()" might add "string" as a native return type declaration in the future. Do the same in child class "Aeon\Doctrine\Calendar\Gregorian\DayType" now to avoid errors or add an explicit @return annotation to suppress this message.
2022-07-04T10:05:39+02:00 [info] User Deprecated: Method "Doctrine\DBAL\Types\Type::convertToDatabaseValue()" might add "mixed" as a native return type declaration in the future. Do the same in child class "Aeon\Doctrine\Calendar\Gregorian\DayType" now to avoid errors or add an explicit @return annotation to suppress this message.
2022-07-04T10:05:39+02:00 [info] User Deprecated: Method "Doctrine\DBAL\Types\Type::convertToPHPValue()" might add "mixed" as a native return type declaration in the future. Do the same in child class "Aeon\Doctrine\Calendar\Gregorian\DayType" now to avoid errors or add an explicit @return annotation to suppress this message.
2022-07-04T10:05:39+02:00 [info] User Deprecated: Method "Doctrine\DBAL\Types\Type::requiresSQLCommentHint()" might add "bool" as a native return type declaration in the future. Do the same in child class "Aeon\Doctrine\Calendar\Gregorian\DayType" now to avoid errors or add an explicit @return annotation to suppress this message.
```

This pull request adds the missing return types to handle those deprecations.